### PR TITLE
fix: replaceAll compatible issue

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "extends": ["galex", "prettier"],
   "env": { "node": true },
   "rules": {
-    "no-console": "off"
+    "no-console": "off",
+    "unicorn/prefer-string-replace-all": "off"
   },
   "plugins": ["prettier"]
 }

--- a/src/modules/toArabicString.ts
+++ b/src/modules/toArabicString.ts
@@ -24,7 +24,7 @@ export const toArabicString = (
 
   return source.replace(NUMBER_IN_STRING_REGEX, (match) => {
     if (match.length >= minimumCharactersInNumber) {
-      return toInteger(match.replaceAll(/[\s,_]/gu, "")).toString();
+      return toInteger(match.replace(/[\s,_]/gu, "")).toString();
     }
     return match;
   });

--- a/src/modules/toInteger.ts
+++ b/src/modules/toInteger.ts
@@ -41,7 +41,7 @@ export const toInteger = (source: string): number => {
     return Number.parseFloat(str) || 0;
   }
 
-  str = str.replaceAll(/[,\s]/gu, ""); // remove commas, spaces
+  str = str.replace(/[,\s]/gu, ""); // remove commas, spaces
 
   // Convert something like 8千3萬 into 8千3百萬 (8300*10000)
   str = addMissingUnits(str);


### PR DESCRIPTION
`String.replaceAll` doesn't make much sense when used with RegExp.

But it can trigger errors in old version runtimes (Browser / Node.js).